### PR TITLE
feat(kubernetes-workload): add support to define custom tags for monitors

### DIFF
--- a/caas/kubernetes/workload/README.md
+++ b/caas/kubernetes/workload/README.md
@@ -60,6 +60,7 @@ Creates DataDog monitors with the following checks:
 | <a name="input_cronjob_extra_tags"></a> [cronjob\_extra\_tags](#input\_cronjob\_extra\_tags) | Extra tags for Cronjob monitor | `list(string)` | `[]` | no |
 | <a name="input_cronjob_message"></a> [cronjob\_message](#input\_cronjob\_message) | Custom message for Cronjob monitor | `string` | `""` | no |
 | <a name="input_cronjob_threshold_warning"></a> [cronjob\_threshold\_warning](#input\_cronjob\_threshold\_warning) | Cronjob monitor (warning threshold) | `string` | `3` | no |
+| <a name="input_custom_tags"></a> [custom\_tags](#input\_custom\_tags) | Custom tags for monitors | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-workload",<br>  "team:claranet",<br>  "created-by:terraform"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |

--- a/caas/kubernetes/workload/README.md
+++ b/caas/kubernetes/workload/README.md
@@ -60,7 +60,8 @@ Creates DataDog monitors with the following checks:
 | <a name="input_cronjob_extra_tags"></a> [cronjob\_extra\_tags](#input\_cronjob\_extra\_tags) | Extra tags for Cronjob monitor | `list(string)` | `[]` | no |
 | <a name="input_cronjob_message"></a> [cronjob\_message](#input\_cronjob\_message) | Custom message for Cronjob monitor | `string` | `""` | no |
 | <a name="input_cronjob_threshold_warning"></a> [cronjob\_threshold\_warning](#input\_cronjob\_threshold\_warning) | Cronjob monitor (warning threshold) | `string` | `3` | no |
-| <a name="input_custom_tags"></a> [custom\_tags](#input\_custom\_tags) | Custom tags for monitors | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-workload",<br>  "team:claranet",<br>  "created-by:terraform"<br>]</pre> | no |
+| <a name="input_custom_tags"></a> [custom\_tags](#input\_custom\_tags) | Custom tags for monitors | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default tags for monitors | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-workload",<br>  "created-by:terraform"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |

--- a/caas/kubernetes/workload/inputs.tf
+++ b/caas/kubernetes/workload/inputs.tf
@@ -4,6 +4,12 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "default_tags" {
+  description = "Default tags for monitors"
+  type        = list(string)
+  default     = ["type:caas", "provider:kubernetes", "resource:kubernetes-workload"]
+}
+
 variable "custom_tags" {
   description = "Custom tags for monitors"
   type        = list(string)

--- a/caas/kubernetes/workload/inputs.tf
+++ b/caas/kubernetes/workload/inputs.tf
@@ -4,6 +4,12 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "custom_tags" {
+  description = "Custom tags for monitors"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/caas/kubernetes/workload/locals.tf
+++ b/caas/kubernetes/workload/locals.tf
@@ -1,3 +1,5 @@
 locals {
   replica_group_by = join(", ", var.replica_group_by)
+
+  default_tags     = ["type:caas", "provider:kubernetes", "resource:kubernetes-workload"]
 }

--- a/caas/kubernetes/workload/locals.tf
+++ b/caas/kubernetes/workload/locals.tf
@@ -1,5 +1,3 @@
 locals {
   replica_group_by = join(", ", var.replica_group_by)
-
-  default_tags     = ["type:caas", "provider:kubernetes", "resource:kubernetes-workload"]
 }

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -22,7 +22,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.job_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.job_extra_tags)
 }
 
 resource "datadog_monitor" "cronjob" {
@@ -49,7 +49,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.cronjob_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.cronjob_extra_tags)
 }
 
 resource "datadog_monitor" "replica_available" {
@@ -79,7 +79,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.replica_available_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.replica_available_extra_tags)
 }
 
 resource "datadog_monitor" "replica_ready" {
@@ -109,7 +109,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.replica_ready_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.replica_ready_extra_tags)
 }
 
 resource "datadog_monitor" "replica_current" {
@@ -139,6 +139,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.replica_current_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.replica_current_extra_tags)
 }
 

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -22,7 +22,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.job_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], var.default_tags, var.custom_tags, var.job_extra_tags)
 }
 
 resource "datadog_monitor" "cronjob" {
@@ -49,7 +49,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.cronjob_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], var.default_tags, var.custom_tags, var.cronjob_extra_tags)
 }
 
 resource "datadog_monitor" "replica_available" {
@@ -79,7 +79,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.replica_available_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], var.default_tags, var.custom_tags, var.replica_available_extra_tags)
 }
 
 resource "datadog_monitor" "replica_ready" {
@@ -109,7 +109,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.replica_ready_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], var.default_tags, var.custom_tags, var.replica_ready_extra_tags)
 }
 
 resource "datadog_monitor" "replica_current" {
@@ -139,6 +139,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "created-by:terraform"], locals.default_tags, var.custom_tags, var.replica_current_extra_tags)
+  tags = concat(["env:${var.environment}", "created-by:terraform"], var.default_tags, var.custom_tags, var.replica_current_extra_tags)
 }
 


### PR DESCRIPTION
This adds a new "custom_tags" input variable to enable us to define custom tags for all the `caas/kubernetes/workload` terraform module monitors