### PR TITLE
feat(kubernetes): use monitor-tags module for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ For example, this will regenerate every READMEs thanks to [terraform-docs](https
 - [common](https://github.com/claranet/terraform-datadog-monitors/tree/master/common/)
 	- [alerting-message](https://github.com/claranet/terraform-datadog-monitors/tree/master/common/alerting-message/)
 	- [filter-tags](https://github.com/claranet/terraform-datadog-monitors/tree/master/common/filter-tags/)
+	- [monitor-tags](https://github.com/claranet/terraform-datadog-monitors/tree/master/common/monitor-tags/)
 - [database](https://github.com/claranet/terraform-datadog-monitors/tree/master/database/)
 	- [elasticsearch](https://github.com/claranet/terraform-datadog-monitors/tree/master/database/elasticsearch/)
 	- [mongodb](https://github.com/claranet/terraform-datadog-monitors/tree/master/database/mongodb/)

--- a/caas/kubernetes/ark/README.md
+++ b/caas/kubernetes/ark/README.md
@@ -37,6 +37,7 @@ Creates DataDog monitors with the following checks:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_filter-tags"></a> [filter-tags](#module\_filter-tags) | ../../../common/filter-tags | n/a |
+| <a name="module_monitor-tags"></a> [monitor-tags](#module\_monitor-tags) | ../../../common/monitor-tags | n/a |
 
 ## Resources
 
@@ -53,8 +54,10 @@ Creates DataDog monitors with the following checks:
 | <a name="input_ark_schedules_monitor_message"></a> [ark\_schedules\_monitor\_message](#input\_ark\_schedules\_monitor\_message) | Custom message for Ark schedules monitor | `string` | `""` | no |
 | <a name="input_ark_schedules_monitor_no_data_timeframe"></a> [ark\_schedules\_monitor\_no\_data\_timeframe](#input\_ark\_schedules\_monitor\_no\_data\_timeframe) | No data timeframe in minutes | `number` | `2880` | no |
 | <a name="input_ark_schedules_monitor_timeframe"></a> [ark\_schedules\_monitor\_timeframe](#input\_ark\_schedules\_monitor\_timeframe) | Monitor timeframe for Ark schedules monitor [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_1d"` | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default list of tags that will be associate to all monitor | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:prometheus",<br>  "resource:ark"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional list of tags to associate to all monitor | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |

--- a/caas/kubernetes/ark/inputs.tf
+++ b/caas/kubernetes/ark/inputs.tf
@@ -4,6 +4,18 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "default_tags" {
+  description = "Default list of tags that will be associate to all monitor"
+  type        = list(string)
+  default     = ["type:caas", "provider:prometheus", "resource:ark"]
+}
+
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/caas/kubernetes/ark/modules.tf
+++ b/caas/kubernetes/ark/modules.tf
@@ -8,3 +8,9 @@ module "filter-tags" {
   filter_tags_custom_excluded = var.filter_tags_custom_excluded
 }
 
+module "monitor-tags" {
+  source = "../../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}

--- a/caas/kubernetes/ark/monitors-ark.tf
+++ b/caas/kubernetes/ark/monitors-ark.tf
@@ -25,6 +25,6 @@ EOQ
   locked              = false
   require_full_window = false
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:prometheus", "resource:ark", "team:claranet", "created-by:terraform"], var.ark_schedules_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.ark_schedules_extra_tags)
 }
 

--- a/caas/kubernetes/cluster/README.md
+++ b/caas/kubernetes/cluster/README.md
@@ -37,6 +37,7 @@ Creates DataDog monitors with the following checks:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_filter-tags"></a> [filter-tags](#module\_filter-tags) | ../../../common/filter-tags | n/a |
+| <a name="module_monitor-tags"></a> [monitor-tags](#module\_monitor-tags) | ../../../common/monitor-tags | n/a |
 
 ## Resources
 
@@ -53,8 +54,10 @@ Creates DataDog monitors with the following checks:
 | <a name="input_apiserver_message"></a> [apiserver\_message](#input\_apiserver\_message) | Custom message for API server monitor | `string` | `""` | no |
 | <a name="input_apiserver_no_data_timeframe"></a> [apiserver\_no\_data\_timeframe](#input\_apiserver\_no\_data\_timeframe) | Number of minutes before reporting no data | `string` | `10` | no |
 | <a name="input_apiserver_threshold_warning"></a> [apiserver\_threshold\_warning](#input\_apiserver\_threshold\_warning) | API server monitor (warning threshold) | `string` | `3` | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default list of tags that will be associate to all monitor | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-cluster"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional list of tags to associate to all monitor | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |

--- a/caas/kubernetes/cluster/inputs.tf
+++ b/caas/kubernetes/cluster/inputs.tf
@@ -4,6 +4,18 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "default_tags" {
+  description = "Default list of tags that will be associate to all monitor"
+  type        = list(string)
+  default     = ["type:caas", "provider:kubernetes", "resource:kubernetes-cluster"]
+}
+
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/caas/kubernetes/cluster/modules.tf
+++ b/caas/kubernetes/cluster/modules.tf
@@ -8,3 +8,9 @@ module "filter-tags" {
   filter_tags_custom_excluded = var.filter_tags_custom_excluded
 }
 
+module "monitor-tags" {
+  source = "../../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}

--- a/caas/kubernetes/cluster/monitors-k8s-cluster.tf
+++ b/caas/kubernetes/cluster/monitors-k8s-cluster.tf
@@ -24,6 +24,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.apiserver_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.apiserver_extra_tags)
 }
 

--- a/caas/kubernetes/ingress/vts/README.md
+++ b/caas/kubernetes/ingress/vts/README.md
@@ -40,6 +40,7 @@ Creates DataDog monitors with the following checks:
 | <a name="module_filter-tags"></a> [filter-tags](#module\_filter-tags) | ../../../../common/filter-tags | n/a |
 | <a name="module_filter-tags-4xx"></a> [filter-tags-4xx](#module\_filter-tags-4xx) | ../../../../common/filter-tags | n/a |
 | <a name="module_filter-tags-5xx"></a> [filter-tags-5xx](#module\_filter-tags-5xx) | ../../../../common/filter-tags | n/a |
+| <a name="module_monitor-tags"></a> [monitor-tags](#module\_monitor-tags) | ../../../../common/monitor-tags | n/a |
 
 ## Resources
 
@@ -53,8 +54,10 @@ Creates DataDog monitors with the following checks:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_artificial_requests_count"></a> [artificial\_requests\_count](#input\_artificial\_requests\_count) | Number of false requests used to mitigate false positive in case of low trafic | `number` | `5` | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default list of tags that will be associate to all monitor | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:prometheus",<br>  "resource:nginx-ingress-controller"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture Environment | `string` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional list of tags to associate to all monitor | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |

--- a/caas/kubernetes/ingress/vts/inputs.tf
+++ b/caas/kubernetes/ingress/vts/inputs.tf
@@ -5,6 +5,18 @@ variable "environment" {
 }
 
 # Global DataDog
+
+variable "default_tags" {
+  description = "Default list of tags that will be associate to all monitor"
+  type        = list(string)
+  default     = ["type:caas", "provider:prometheus", "resource:nginx-ingress-controller"]
+}
+
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
 variable "evaluation_delay" {
   description = "Delay in seconds for the metric evaluation"
   default     = 15

--- a/caas/kubernetes/ingress/vts/modules.tf
+++ b/caas/kubernetes/ingress/vts/modules.tf
@@ -33,3 +33,9 @@ module "filter-tags-4xx" {
   extra_tags_excluded         = ["upstream:upstream-default-backend"]
 }
 
+module "monitor-tags" {
+  source = "../../../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}

--- a/caas/kubernetes/ingress/vts/monitors-ingress.tf
+++ b/caas/kubernetes/ingress/vts/monitors-ingress.tf
@@ -26,7 +26,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:prometheus", "resource:nginx-ingress-controller", "team:claranet", "created-by:terraform"], var.ingress_5xx_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.ingress_5xx_extra_tags)
 }
 
 resource "datadog_monitor" "nginx_ingress_too_many_4xx" {
@@ -57,6 +57,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:prometheus", "resource:nginx-ingress-controller", "team:claranet", "created-by:terraform"], var.ingress_4xx_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.ingress_4xx_extra_tags)
 }
 

--- a/caas/kubernetes/node/README.md
+++ b/caas/kubernetes/node/README.md
@@ -47,6 +47,7 @@ Creates DataDog monitors with the following checks:
 |------|--------|---------|
 | <a name="module_filter-tags"></a> [filter-tags](#module\_filter-tags) | ../../../common/filter-tags | n/a |
 | <a name="module_filter-tags-unschedulable"></a> [filter-tags-unschedulable](#module\_filter-tags-unschedulable) | ../../../common/filter-tags | n/a |
+| <a name="module_monitor-tags"></a> [monitor-tags](#module\_monitor-tags) | ../../../common/monitor-tags | n/a |
 
 ## Resources
 
@@ -67,6 +68,7 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default list of tags that will be associate to all monitor | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-node"<br>]</pre> | no |
 | <a name="input_disk_out_enabled"></a> [disk\_out\_enabled](#input\_disk\_out\_enabled) | Flag to enable Out of disk monitor | `string` | `"true"` | no |
 | <a name="input_disk_out_extra_tags"></a> [disk\_out\_extra\_tags](#input\_disk\_out\_extra\_tags) | Extra tags for Out of disk monitor | `list(string)` | `[]` | no |
 | <a name="input_disk_out_message"></a> [disk\_out\_message](#input\_disk\_out\_message) | Custom message for Out of disk monitor | `string` | `""` | no |
@@ -77,6 +79,7 @@ Creates DataDog monitors with the following checks:
 | <a name="input_disk_pressure_threshold_warning"></a> [disk\_pressure\_threshold\_warning](#input\_disk\_pressure\_threshold\_warning) | Disk pressure monitor (warning threshold) | `string` | `3` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional list of tags to associate to all monitor | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |

--- a/caas/kubernetes/node/inputs.tf
+++ b/caas/kubernetes/node/inputs.tf
@@ -4,6 +4,18 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "default_tags" {
+  description = "Default list of tags that will be associate to all monitor"
+  type        = list(string)
+  default     = ["type:caas", "provider:kubernetes", "resource:kubernetes-node"]
+}
+
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/caas/kubernetes/node/modules.tf
+++ b/caas/kubernetes/node/modules.tf
@@ -19,3 +19,9 @@ module "filter-tags-unschedulable" {
   extra_tags                  = ["status:unschedulable"]
 }
 
+module "monitor-tags" {
+  source = "../../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}

--- a/caas/kubernetes/node/monitors-k8s-node.tf
+++ b/caas/kubernetes/node/monitors-k8s-node.tf
@@ -22,7 +22,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.disk_pressure_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.disk_pressure_extra_tags)
 }
 
 resource "datadog_monitor" "disk_out" {
@@ -49,7 +49,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.disk_out_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.disk_out_extra_tags)
 }
 
 resource "datadog_monitor" "memory_pressure" {
@@ -76,7 +76,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.memory_pressure_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.memory_pressure_extra_tags)
 }
 
 resource "datadog_monitor" "ready" {
@@ -103,7 +103,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.ready_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.ready_extra_tags)
 }
 
 resource "datadog_monitor" "kubelet_ping" {
@@ -131,7 +131,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.kubelet_ping_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.kubelet_ping_extra_tags)
 }
 
 resource "datadog_monitor" "kubelet_syncloop" {
@@ -158,7 +158,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.kubelet_syncloop_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.kubelet_syncloop_extra_tags)
 }
 
 resource "datadog_monitor" "unregister_net_device" {
@@ -179,7 +179,7 @@ EOQ
   include_tags      = true
   locked            = false
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.unregister_net_device_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.unregister_net_device_extra_tags)
 }
 
 resource "datadog_monitor" "node_unschedulable" {
@@ -208,7 +208,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.node_unschedulable_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.node_unschedulable_extra_tags)
 }
 
 resource "datadog_monitor" "volume_space" {
@@ -239,7 +239,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.volume_space_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.volume_space_extra_tags)
 }
 
 resource "datadog_monitor" "volume_inodes" {
@@ -270,6 +270,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-node", "team:claranet", "created-by:terraform"], var.volume_inodes_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.volume_inodes_extra_tags)
 }
 

--- a/caas/kubernetes/pod/README.md
+++ b/caas/kubernetes/pod/README.md
@@ -41,6 +41,7 @@ Creates DataDog monitors with the following checks:
 | <a name="module_filter-tags"></a> [filter-tags](#module\_filter-tags) | ../../../common/filter-tags | n/a |
 | <a name="module_filter-tags-nocontainercreating"></a> [filter-tags-nocontainercreating](#module\_filter-tags-nocontainercreating) | ../../../common/filter-tags | n/a |
 | <a name="module_filter-tags-phase"></a> [filter-tags-phase](#module\_filter-tags-phase) | ../../../common/filter-tags | n/a |
+| <a name="module_monitor-tags"></a> [monitor-tags](#module\_monitor-tags) | ../../../common/monitor-tags | n/a |
 
 ## Resources
 
@@ -54,6 +55,7 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default list of tags that will be associate to all monitor | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-pod"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_error_enabled"></a> [error\_enabled](#input\_error\_enabled) | Flag to enable Pod errors monitor | `string` | `"true"` | no |
 | <a name="input_error_extra_tags"></a> [error\_extra\_tags](#input\_error\_extra\_tags) | Extra tags for Pod errors monitor | `list(string)` | `[]` | no |
@@ -63,6 +65,7 @@ Creates DataDog monitors with the following checks:
 | <a name="input_error_time_aggregator"></a> [error\_time\_aggregator](#input\_error\_time\_aggregator) | Monitor aggregator for Pod errors [available values: min, max or avg] | `string` | `"min"` | no |
 | <a name="input_error_timeframe"></a> [error\_timeframe](#input\_error\_timeframe) | Monitor timeframe for Pod errors [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_15m"` | no |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional list of tags to associate to all monitor | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |

--- a/caas/kubernetes/pod/inputs.tf
+++ b/caas/kubernetes/pod/inputs.tf
@@ -4,6 +4,18 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "default_tags" {
+  description = "Default list of tags that will be associate to all monitor"
+  type        = list(string)
+  default     = ["type:caas", "provider:kubernetes", "resource:kubernetes-pod"]
+}
+
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/caas/kubernetes/pod/modules.tf
+++ b/caas/kubernetes/pod/modules.tf
@@ -30,3 +30,9 @@ module "filter-tags-nocontainercreating" {
   extra_tags_excluded         = ["reason:containercreating"]
 }
 
+module "monitor-tags" {
+  source = "../../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}

--- a/caas/kubernetes/pod/monitors-k8s-pod.tf
+++ b/caas/kubernetes/pod/monitors-k8s-pod.tf
@@ -24,7 +24,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-pod", "team:claranet", "created-by:terraform"], var.pod_phase_status_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.pod_phase_status_extra_tags)
 }
 
 resource "datadog_monitor" "error" {
@@ -54,7 +54,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-pod", "team:claranet", "created-by:terraform"], var.error_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.error_extra_tags)
 }
 
 resource "datadog_monitor" "terminated" {
@@ -84,6 +84,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-pod", "team:claranet", "created-by:terraform"], var.terminated_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.terminated_extra_tags)
 }
 

--- a/caas/kubernetes/velero/README.md
+++ b/caas/kubernetes/velero/README.md
@@ -42,6 +42,7 @@ Creates DataDog monitors with the following checks:
 |------|--------|---------|
 | <a name="module_filter-tags"></a> [filter-tags](#module\_filter-tags) | ../../../common/filter-tags | n/a |
 | <a name="module_filter-tags-scheduled-backup"></a> [filter-tags-scheduled-backup](#module\_filter-tags-scheduled-backup) | ../../../common/filter-tags | n/a |
+| <a name="module_monitor-tags"></a> [monitor-tags](#module\_monitor-tags) | ../../../common/monitor-tags | n/a |
 
 ## Resources
 
@@ -57,8 +58,10 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default list of tags that will be associate to all monitor | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:openmetrics",<br>  "resource:velero"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional list of tags to associate to all monitor | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |

--- a/caas/kubernetes/velero/inputs.tf
+++ b/caas/kubernetes/velero/inputs.tf
@@ -4,6 +4,18 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "default_tags" {
+  description = "Default list of tags that will be associate to all monitor"
+  type        = list(string)
+  default     = ["type:caas", "provider:openmetrics", "resource:velero"]
+}
+
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/caas/kubernetes/velero/modules.tf
+++ b/caas/kubernetes/velero/modules.tf
@@ -18,3 +18,10 @@ module "filter-tags-scheduled-backup" {
   filter_tags_custom_excluded = var.filter_tags_custom_excluded
   extra_tags_excluded         = ["schedule:"]
 }
+
+module "monitor-tags" {
+  source = "../../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}

--- a/caas/kubernetes/velero/monitors-velero.tf
+++ b/caas/kubernetes/velero/monitors-velero.tf
@@ -24,7 +24,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:openmetrics", "resource:velero", "team:claranet", "created-by:terraform"], var.velero_scheduled_backup_missing_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.velero_scheduled_backup_missing_extra_tags)
 }
 
 resource "datadog_monitor" "velero_backup_failure" {
@@ -53,7 +53,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:openmetrics", "resource:velero", "team:claranet", "created-by:terraform"], var.velero_backup_failure_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.velero_backup_failure_extra_tags)
 }
 
 resource "datadog_monitor" "velero_backup_partial_failure" {
@@ -82,7 +82,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:openmetrics", "resource:velero", "team:claranet", "created-by:terraform"], var.velero_backup_partial_failure_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.velero_backup_partial_failure_extra_tags)
 }
 
 resource "datadog_monitor" "velero_backup_deletion_failure" {
@@ -111,7 +111,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:openmetrics", "resource:velero", "team:claranet", "created-by:terraform"], var.velero_backup_deletion_failure_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.velero_backup_deletion_failure_extra_tags)
 }
 
 resource "datadog_monitor" "velero_volume_snapshot_failure" {
@@ -140,6 +140,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:openmetrics", "resource:velero", "team:claranet", "created-by:terraform"], var.velero_volume_snapshot_failure_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.velero_volume_snapshot_failure_extra_tags)
 }
 

--- a/caas/kubernetes/workload/README.md
+++ b/caas/kubernetes/workload/README.md
@@ -41,6 +41,7 @@ Creates DataDog monitors with the following checks:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_filter-tags"></a> [filter-tags](#module\_filter-tags) | ../../../common/filter-tags | n/a |
+| <a name="module_monitor-tags"></a> [monitor-tags](#module\_monitor-tags) | ../../../common/monitor-tags | n/a |
 
 ## Resources
 
@@ -60,8 +61,10 @@ Creates DataDog monitors with the following checks:
 | <a name="input_cronjob_extra_tags"></a> [cronjob\_extra\_tags](#input\_cronjob\_extra\_tags) | Extra tags for Cronjob monitor | `list(string)` | `[]` | no |
 | <a name="input_cronjob_message"></a> [cronjob\_message](#input\_cronjob\_message) | Custom message for Cronjob monitor | `string` | `""` | no |
 | <a name="input_cronjob_threshold_warning"></a> [cronjob\_threshold\_warning](#input\_cronjob\_threshold\_warning) | Cronjob monitor (warning threshold) | `string` | `3` | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default list of tags that will be associate to all monitor | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-workload"<br>]</pre> | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture environment | `any` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional list of tags to associate to all monitor | `list(string)` | <pre>[<br>  "team:claranet"<br>]</pre> | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |

--- a/caas/kubernetes/workload/inputs.tf
+++ b/caas/kubernetes/workload/inputs.tf
@@ -4,6 +4,18 @@ variable "environment" {
   description = "Architecture environment"
 }
 
+variable "default_tags" {
+  description = "Default list of tags that will be associate to all monitor"
+  type        = list(string)
+  default     = ["type:caas", "provider:kubernetes", "resource:kubernetes-workload"]
+}
+
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = ["team:claranet"]
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/caas/kubernetes/workload/modules.tf
+++ b/caas/kubernetes/workload/modules.tf
@@ -8,3 +8,9 @@ module "filter-tags" {
   filter_tags_custom_excluded = var.filter_tags_custom_excluded
 }
 
+module "monitor-tags" {
+  source = "../../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -22,7 +22,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.job_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.job_extra_tags)
 }
 
 resource "datadog_monitor" "cronjob" {
@@ -49,7 +49,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.cronjob_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.cronjob_extra_tags)
 }
 
 resource "datadog_monitor" "replica_available" {
@@ -79,7 +79,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.replica_available_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.replica_available_extra_tags)
 }
 
 resource "datadog_monitor" "replica_ready" {
@@ -109,7 +109,7 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.replica_ready_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.replica_ready_extra_tags)
 }
 
 resource "datadog_monitor" "replica_current" {
@@ -139,6 +139,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:caas", "provider:kubernetes", "resource:kubernetes-workload", "team:claranet", "created-by:terraform"], var.replica_current_extra_tags)
+  tags = concat(module.monitor-tags.tags, var.replica_current_extra_tags)
 }
 

--- a/common/monitor-tags/README.md
+++ b/common/monitor-tags/README.md
@@ -1,0 +1,47 @@
+# MONITOR TAGS Datadog Generator
+
+## How to use this module
+
+This module usage should be transparent because it should be used inside each monitors set directly.
+Here is a simple example but it is advisable to see how are created other existing monitors sets:
+
+```
+module "monitor-tags" {
+  source = "../../common/monitor-tags"
+
+  environment  = "${var.environment}"
+  extra_tags   = "${var.extra_tags}"
+}
+```
+
+## Purpose
+
+Creates a default and a extra list of tags to associate with your monitor. This can help you categorize and filter monitors in the manage monitors page of the UI. 
+Note: it's not currently possible to filter by these tags when querying via the API
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_environment"></a> [environment](#input\_environment) | Architecture Environment | `string` | n/a | yes |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra optional tags added to include filtering in any case (i.e. ["tag1:val1", "tag2:val2"]) | `list(string)` | `[]` | no |
+| <a name="input_extra_tags_excluded"></a> [extra\_tags\_excluded](#input\_extra\_tags\_excluded) | Extra optional tags added to exclude filtering in any case (i.e. ["tag1:val1", "tag2:val2"]) | `list(string)` | `[]` | no |
+| <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false (i.e. "tag1:val1,tag2:val2") | `string` | `"*"` | no |
+| <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false (i.e. "tag1:val1,tag2:val2") | `string` | `""` | no |
+| <a name="input_filter_tags_separator"></a> [filter\_tags\_separator](#input\_filter\_tags\_separator) | Set the query separator (, or AND) | `string` | `","` | no |
+| <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |
+| <a name="input_resource"></a> [resource](#input\_resource) | The dedicated tag for the resource | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_event_alert"></a> [event\_alert](#output\_event\_alert) | The full filtering pattern for event alert monitor type |
+| <a name="output_query_alert"></a> [query\_alert](#output\_query\_alert) | The full filtering pattern including parentheses for service check monitor type |
+| <a name="output_service_check"></a> [service\_check](#output\_service\_check) | The full filtering pattern including braces for query alert monitor type |
+
+## Related documentation
+
+Datadog API type of monitor: [https://docs.datadoghq.com/api/?lang=python#create-a-monitor](https://docs.datadoghq.com/api/?lang=python#create-a-monitor)
+Terraform guide: [https://www.terraform.io/docs/configuration-0-11/interpolation.html](https://www.terraform.io/docs/configuration-0-11/interpolation.html)
+

--- a/common/monitor-tags/inputs.tf
+++ b/common/monitor-tags/inputs.tf
@@ -1,0 +1,16 @@
+variable "environment" {
+  description = "Architecture Environment"
+  type        = string
+}
+
+variable "default_tags" {
+  description = "Default tags added to include in any case (i.e. [\"tag1:val1\", \"tag2:val2\"])"
+  type        = list(string)
+  default     = []
+}
+
+variable "extra_tags" {
+  description = "Extra optional tags added to include in any case (i.e. [\"tag1:val1\", \"tag2:val2\"])"
+  type        = list(string)
+  default     = []
+}

--- a/common/monitor-tags/outputs.tf
+++ b/common/monitor-tags/outputs.tf
@@ -1,0 +1,10 @@
+# Inputs example values:
+#TF_VAR_environment='prod' TF_VAR_default_tags="tag:val,tag2:val2" TF_VAR_extra_tags="tag3:val3,tag4:val4" terraform apply
+
+# query_alert = ["tag:val", "tag2:val2"]
+output "tags" {
+  description = "The full list of tags for monitors"
+  value       = concat(["env:${var.environment}", "created-by:terraform"], var.default_tags, var.extra_tags)
+}
+
+


### PR DESCRIPTION
Adds a common/monitor-tags module and use it to define tags for monitors