### PR TITLE
feat(kubernetes): support for monitor name prefix

### DIFF
--- a/caas/kubernetes/ark/inputs.tf
+++ b/caas/kubernetes/ark/inputs.tf
@@ -50,6 +50,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/caas/kubernetes/ark/monitors-ark.tf
+++ b/caas/kubernetes/ark/monitors-ark.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "ark_schedules_monitor" {
   count   = var.ark_schedules_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Ark backup failed"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Ark backup failed"
   type    = "query alert"
   message = coalesce(var.ark_schedules_monitor_message, var.message)
 

--- a/caas/kubernetes/cluster/inputs.tf
+++ b/caas/kubernetes/cluster/inputs.tf
@@ -50,6 +50,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/caas/kubernetes/cluster/monitors-k8s-cluster.tf
+++ b/caas/kubernetes/cluster/monitors-k8s-cluster.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "apiserver" {
   count   = var.apiserver_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes API server does not respond"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes API server does not respond"
   message = coalesce(var.apiserver_message, var.message)
 
   type = "service check"

--- a/caas/kubernetes/ingress/vts/inputs.tf
+++ b/caas/kubernetes/ingress/vts/inputs.tf
@@ -32,6 +32,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/caas/kubernetes/ingress/vts/monitors-ingress.tf
+++ b/caas/kubernetes/ingress/vts/monitors-ingress.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "nginx_ingress_too_many_5xx" {
   count   = var.ingress_5xx_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Nginx Ingress 5xx errors {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Nginx Ingress 5xx errors {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.ingress_5xx_message, var.message)
   type    = "query alert"
 
@@ -31,7 +31,7 @@ EOQ
 
 resource "datadog_monitor" "nginx_ingress_too_many_4xx" {
   count   = var.ingress_4xx_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Nginx Ingress 4xx errors {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Nginx Ingress 4xx errors {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.ingress_4xx_message, var.message)
   type    = "query alert"
 

--- a/caas/kubernetes/node/inputs.tf
+++ b/caas/kubernetes/node/inputs.tf
@@ -50,6 +50,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/caas/kubernetes/node/monitors-k8s-node.tf
+++ b/caas/kubernetes/node/monitors-k8s-node.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "disk_pressure" {
   count   = var.disk_pressure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Disk pressure"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node Disk pressure"
   message = coalesce(var.disk_pressure_message, var.message)
   type    = "service check"
 
@@ -27,7 +27,7 @@ EOQ
 
 resource "datadog_monitor" "disk_out" {
   count   = var.disk_out_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Out of disk"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node Out of disk"
   message = coalesce(var.disk_out_message, var.message)
   type    = "service check"
 
@@ -54,7 +54,7 @@ EOQ
 
 resource "datadog_monitor" "memory_pressure" {
   count   = var.memory_pressure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Memory pressure"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node Memory pressure"
   message = coalesce(var.memory_pressure_message, var.message)
   type    = "service check"
 
@@ -81,7 +81,7 @@ EOQ
 
 resource "datadog_monitor" "ready" {
   count   = var.ready_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node not ready"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node not ready"
   message = coalesce(var.ready_message, var.message)
   type    = "service check"
 
@@ -108,7 +108,7 @@ EOQ
 
 resource "datadog_monitor" "kubelet_ping" {
   count   = var.kubelet_ping_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Kubelet API does not respond"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node Kubelet API does not respond"
   message = coalesce(var.kubelet_ping_message, var.message)
   type    = "service check"
 
@@ -136,7 +136,7 @@ EOQ
 
 resource "datadog_monitor" "kubelet_syncloop" {
   count   = var.kubelet_syncloop_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Kubelet sync loop that updates containers does not work"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node Kubelet sync loop that updates containers does not work"
   message = coalesce(var.kubelet_syncloop_message, var.message)
   type    = "service check"
 
@@ -163,7 +163,7 @@ EOQ
 
 resource "datadog_monitor" "unregister_net_device" {
   count   = var.unregister_net_device_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Frequent unregister net device"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node Frequent unregister net device"
   message = coalesce(var.unregister_net_device_message, var.message)
   type    = "event alert"
 
@@ -184,7 +184,7 @@ EOQ
 
 resource "datadog_monitor" "node_unschedulable" {
   count   = var.node_unschedulable_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node unschedulable"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node unschedulable"
   message = coalesce(var.node_unschedulable_message, var.message)
   type    = "metric alert"
 
@@ -213,7 +213,7 @@ EOQ
 
 resource "datadog_monitor" "volume_space" {
   count   = var.volume_space_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node volume space usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node volume space usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.volume_space_message, var.message)
   type    = "query alert"
 
@@ -244,7 +244,7 @@ EOQ
 
 resource "datadog_monitor" "volume_inodes" {
   count   = var.volume_inodes_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node volume inodes usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Node volume inodes usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.volume_inodes_message, var.message)
   type    = "query alert"
 

--- a/caas/kubernetes/pod/inputs.tf
+++ b/caas/kubernetes/pod/inputs.tf
@@ -50,6 +50,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/caas/kubernetes/pod/monitors-k8s-pod.tf
+++ b/caas/kubernetes/pod/monitors-k8s-pod.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "pod_phase_status" {
   count   = var.pod_phase_status_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Pod phase status failed"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Pod phase status failed"
   message = coalesce(var.pod_phase_status_message, var.message)
   type    = "metric alert"
 
@@ -29,7 +29,7 @@ EOQ
 
 resource "datadog_monitor" "error" {
   count   = var.error_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Pod waiting errors"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Pod waiting errors"
   message = coalesce(var.error_message, var.message)
   type    = "query alert"
 
@@ -59,7 +59,7 @@ EOQ
 
 resource "datadog_monitor" "terminated" {
   count   = var.terminated_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Pod terminated abnormally"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Pod terminated abnormally"
   message = coalesce(var.terminated_message, var.message)
   type    = "query alert"
 

--- a/caas/kubernetes/velero/inputs.tf
+++ b/caas/kubernetes/velero/inputs.tf
@@ -50,6 +50,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/caas/kubernetes/velero/monitors-velero.tf
+++ b/caas/kubernetes/velero/monitors-velero.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "velero_scheduled_backup_missing" {
   count   = var.velero_scheduled_backup_missing_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Velero scheduled backup missing"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Velero scheduled backup missing"
   type    = "query alert"
   message = coalesce(var.velero_scheduled_backup_missing_monitor_message, var.message)
 
@@ -29,7 +29,7 @@ EOQ
 
 resource "datadog_monitor" "velero_backup_failure" {
   count   = var.velero_backup_failure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Velero backup failure"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Velero backup failure"
   type    = "query alert"
   message = coalesce(var.velero_backup_failure_monitor_message, var.message)
 
@@ -58,7 +58,7 @@ EOQ
 
 resource "datadog_monitor" "velero_backup_partial_failure" {
   count   = var.velero_backup_partial_failure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Velero backup partial failure"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Velero backup partial failure"
   type    = "query alert"
   message = coalesce(var.velero_backup_partial_failure_monitor_message, var.message)
 
@@ -87,7 +87,7 @@ EOQ
 
 resource "datadog_monitor" "velero_backup_deletion_failure" {
   count   = var.velero_backup_deletion_failure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Velero backup deletion failure"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Velero backup deletion failure"
   type    = "query alert"
   message = coalesce(var.velero_backup_deletion_failure_monitor_message, var.message)
 
@@ -116,7 +116,7 @@ EOQ
 
 resource "datadog_monitor" "velero_volume_snapshot_failure" {
   count   = var.velero_volume_snapshot_failure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Velero volume snapshot failure"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Velero volume snapshot failure"
   type    = "query alert"
   message = coalesce(var.velero_volume_snapshot_failure_monitor_message, var.message)
 

--- a/caas/kubernetes/workload/inputs.tf
+++ b/caas/kubernetes/workload/inputs.tf
@@ -50,6 +50,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "job" {
   count   = var.job_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes job failed"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes job failed"
   message = coalesce(var.job_message, var.message)
   type    = "service check"
 
@@ -27,7 +27,7 @@ EOQ
 
 resource "datadog_monitor" "cronjob" {
   count   = var.cronjob_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes cronjob scheduling failed"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes cronjob scheduling failed"
   message = coalesce(var.cronjob_message, var.message)
   type    = "service check"
 
@@ -54,7 +54,7 @@ EOQ
 
 resource "datadog_monitor" "replica_available" {
   count   = var.replica_available_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Available replicas {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Available replicas {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.replica_available_message, var.message)
   type    = "query alert"
 
@@ -84,7 +84,7 @@ EOQ
 
 resource "datadog_monitor" "replica_ready" {
   count   = var.replica_ready_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Ready replicas {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Ready replicas {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.replica_ready_message, var.message)
   type    = "query alert"
 
@@ -114,7 +114,7 @@ EOQ
 
 resource "datadog_monitor" "replica_current" {
   count   = var.replica_current_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Current replicas {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Kubernetes Current replicas {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.replica_current_message, var.message)
   type    = "query alert"
 


### PR DESCRIPTION
This adds support to define a complete prefix for kubernetes monitors name