### PR TITLE
feat(kubernetes/workloads): support group by for job monitor

### DIFF
--- a/caas/kubernetes/workload/inputs.tf
+++ b/caas/kubernetes/workload/inputs.tf
@@ -89,6 +89,11 @@ variable "job_extra_tags" {
   default     = []
 }
 
+variable "job_group_by" {
+  default     = "kube_job"
+  description = "Group by element for job monitor"
+}
+
 variable "job_message" {
   description = "Custom message for Job monitor"
   type        = string
@@ -234,4 +239,3 @@ variable "replica_group_by" {
   default     = ["namespace", "replicaset"]
   description = "Select group by element on monitors"
 }
-

--- a/caas/kubernetes/workload/locals.tf
+++ b/caas/kubernetes/workload/locals.tf
@@ -1,3 +1,4 @@
 locals {
   replica_group_by = join(", ", var.replica_group_by)
+  job_group_by = var.job_group_by
 }

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -5,7 +5,7 @@ resource "datadog_monitor" "job" {
   type    = "service check"
 
   query = <<EOQ
-    "kubernetes_state.job.complete"${module.filter-tags.service_check}.by("job_name").last(6).count_by_status()
+    "kubernetes_state.job.complete"${module.filter-tags.service_check}.by(${local.job_group_by}).last(6).count_by_status()
 EOQ
 
   monitor_thresholds {


### PR DESCRIPTION
Adds a new group by input variable `job_group_by` as a single string to the `caas/kubernetes/workload` job monitor, to add filters for the `by` element of the query