### PR TITLE
refactor(kubernetes/workloads): Change query to get a percent for replicas ready

### DIFF
--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -93,8 +93,8 @@ resource "datadog_monitor" "replica_ready" {
 
   query = <<EOQ
     ${var.replica_ready_time_aggregator}(${var.replica_ready_timeframe}):
-      max:kubernetes_state.replicaset.replicas_desired${module.filter-tags.query_alert} by {${local.replica_group_by}} -
-      max:kubernetes_state.replicaset.replicas_ready${module.filter-tags.query_alert} by {${local.replica_group_by}}
+      ((max:kubernetes_state.replicaset.replicas_desired${module.filter-tags.query_alert} by {${local.replica_group_by}} -
+      max:kubernetes_state.replicaset.replicas_ready${module.filter-tags.query_alert} by {${local.replica_group_by}}) / max:kubernetes_state.replicaset.replicas_desired${module.filter-tags.query_alert} by {${local.replica_group_by}}) * 100
       > ${var.replica_ready_threshold_critical}
 EOQ
 


### PR DESCRIPTION
The query for Replicas_ready is modified to obtain the percentage of available replicas and this can be used across any size of Replicaset