### PR TITLE
feat(kubernetes/node): support for custom group by for volume monitors

### DIFF
--- a/caas/kubernetes/node/README.md
+++ b/caas/kubernetes/node/README.md
@@ -119,6 +119,7 @@ Creates DataDog monitors with the following checks:
 | <a name="input_unregister_net_device_threshold_critical"></a> [unregister\_net\_device\_threshold\_critical](#input\_unregister\_net\_device\_threshold\_critical) | Unregister net device critical threshold | `number` | `3` | no |
 | <a name="input_unregister_net_device_time_aggregator"></a> [unregister\_net\_device\_time\_aggregator](#input\_unregister\_net\_device\_time\_aggregator) | Monitor aggregator for Unregister net device [available values: min, max or avg] | `string` | `"min"` | no |
 | <a name="input_unregister_net_device_timeframe"></a> [unregister\_net\_device\_timeframe](#input\_unregister\_net\_device\_timeframe) | Monitor timeframe for Unregister net device [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"15m"` | no |
+| <a name="input_volume_group_by"></a> [volume\_group\_by](#input\_volume\_group_by) | Select group by element on volume monitors | `list(string)` | `"name", "persistentvolumeclaim"` | no |
 | <a name="input_volume_inodes_enabled"></a> [volume\_inodes\_enabled](#input\_volume\_inodes\_enabled) | Flag to enable Volume inodes monitor | `string` | `"true"` | no |
 | <a name="input_volume_inodes_extra_tags"></a> [volume\_inodes\_extra\_tags](#input\_volume\_inodes\_extra\_tags) | Extra tags for Volume inodes monitor | `list(string)` | `[]` | no |
 | <a name="input_volume_inodes_message"></a> [volume\_inodes\_message](#input\_volume\_inodes\_message) | Custom message for Volume inodes monitor | `string` | `""` | no |

--- a/caas/kubernetes/node/inputs.tf
+++ b/caas/kubernetes/node/inputs.tf
@@ -372,3 +372,7 @@ variable "volume_inodes_threshold_warning" {
   description = "Volume inodes warning threshold"
 }
 
+variable "volume_group_by" {
+  default     = ["name", "persistentvolumeclaim"]
+  description = "Select group by element on volume monitors"
+}

--- a/caas/kubernetes/node/locals.tf
+++ b/caas/kubernetes/node/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  volume_group_by = join(", ", var.volume_group_by)
+}

--- a/caas/kubernetes/node/monitors-k8s-node.tf
+++ b/caas/kubernetes/node/monitors-k8s-node.tf
@@ -227,8 +227,8 @@ resource "datadog_monitor" "volume_space" {
 
   query = <<EOQ
     ${var.volume_space_time_aggregator}(${var.volume_space_timeframe}):
-      avg:kubernetes.kubelet.volume.stats.used_bytes${module.filter-tags.query_alert} by {name,persistentvolumeclaim} /
-      avg:kubernetes.kubelet.volume.stats.capacity_bytes${module.filter-tags.query_alert} by {name,persistentvolumeclaim}
+      avg:kubernetes.kubelet.volume.stats.used_bytes${module.filter-tags.query_alert} by {${local.volume_group_by}} /
+      avg:kubernetes.kubelet.volume.stats.capacity_bytes${module.filter-tags.query_alert} by {${local.volume_group_by}}
     * 100 > ${var.volume_space_threshold_critical}
 EOQ
 
@@ -259,8 +259,8 @@ resource "datadog_monitor" "volume_inodes" {
 
   query = <<EOQ
     ${var.volume_inodes_time_aggregator}(${var.volume_inodes_timeframe}):
-      avg:kubernetes.kubelet.volume.stats.inodes_used${module.filter-tags.query_alert} by {name,persistentvolumeclaim} /
-      avg:kubernetes.kubelet.volume.stats.inodes${module.filter-tags.query_alert} by {name,persistentvolumeclaim}
+      avg:kubernetes.kubelet.volume.stats.inodes_used${module.filter-tags.query_alert} by {${local.volume_group_by}} /
+      avg:kubernetes.kubelet.volume.stats.inodes${module.filter-tags.query_alert} by {${local.volume_group_by}}
     * 100 > ${var.volume_inodes_threshold_critical}
 EOQ
 


### PR DESCRIPTION
Adds a new group by input variable `volume_group_by` to the `caas/kubernetes/node` volume monitors, to add filters for the `by` element of the queries