### PR TITLE
feat(generic/system): support extra custom tags as monitor tags

### DIFF
--- a/system/generic/inputs.tf
+++ b/system/generic/inputs.tf
@@ -44,6 +44,12 @@ variable "message" {
   description = "Message sent when an alert is triggered"
 }
 
+variable "extra_tags" {
+  description = "Extra optional list of tags to associate to all monitor"
+  type        = list(string)
+  default     = []
+}
+
 variable "filter_tags_use_defaults" {
   description = "Use default filter tags convention"
   default     = "true"

--- a/system/generic/modules.tf
+++ b/system/generic/modules.tf
@@ -21,3 +21,9 @@ module "filter-tags-disk" {
   filter_tags_separator       = var.filter_tags_separator
 }
 
+module "monitor-tags" {
+  source = "../../common/monitor-tags"
+
+  environment = var.environment
+  extra_tags  = var.extra_tags
+}


### PR DESCRIPTION
This adds support to add custom tags using the internal monitor tags module for the system/generic module